### PR TITLE
Clarity wording and fix capilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cabbage is the easiest way to get logs out of your k8s cluster and into [Papertr
 
 > __Warning:__ You need a pull secret for quay.io/solarwinds in your cluster! If you don't have access to quay, build the image yourself and push it to your registry.
 
-By default, cabbage runs in `kube-system` namespace and will observe all logs from all pods in all namespaces except from itself or any other service in `kube-system`.
+By default, cabbage runs in the `kube-system` namespace and will observe all logs from all pods in all namespaces except from itself or any other service in `kube-system`.
 
 In `logging-config-patch.yaml` follow the comments to setup the connection to the syslog sink (Papertrail in this example) and set a system tag for the syslog messages.
 
@@ -18,38 +18,38 @@ Cabbage deploys a customized `kail` in an alpine container, using it to query th
 To learn more about filters, read the [kail usage guide](https://github.com/boz/kail/tree/eb6734178238dc794641e82779855fabc2071e23#usage).
 
 ### Papertrail
-In order to ship logs to papertrail, you will need a papertrail account. If you don't have one already you can sign up for one [here](https://www.papertrail.com/). After you are logged in, you will need to create a `Log Destination` from under the `Settings` menu. When a log destination is created you will be given a host:port combo.
+In order to ship logs to Papertrail, you will need a Papertrail account. If you don't have one already, you can sign up for one [here](https://www.papertrail.com/). After you are logged in, you will need to create a `Log Destination` from under the `Settings` menu. When a log destination is created, you will be given a host:port combo.
 
 **Environment variables**
-- `PAPERTRAIL_PROTOCOL` - Acceptable values are udp, tcp, tls. This also depends on the choices that are selected under the - `Destination Settings`. tls and udp are the default choices.
+- `PAPERTRAIL_PROTOCOL` - Acceptable values are udp, tcp, tls. This also depends on the choices that are selected under the `Destination Settings`; by default, a new destination accepts TLS and UDP connections.
 - `PAPERTRAIL_HOST` - Log destination host
 - `PAPERTRAIL_PORT` - Log destination port
 
 You can update the `logging-secrets.yaml` and `logging-config-patch.yaml` files accordingly with these values, remove the unused ones and use `kubectl apply...` as described above.
 
-For any help with papertrail, please checkout their help page [here](https://help.papertrailapp.com/).
+For any help with Papertrail, please check out their help page [here](https://help.papertrailapp.com/).
 
-Apart from the environment variables, we have also added some extra flags to help configure the papertrail log shipper.
-`--pt-db-location` - Location for temporary db used by papertrail shipper. Default value is "./db".
-`--pt-data-retention` - Retention period for local papertrail log data. Default value is "4h".
+Apart from the environment variables, we have also added some extra flags to help configure the Papertrail log shipper.
+`--pt-db-location` - Location for temporary db used by Papertrail shipper. Default value is "./db".
+`--pt-data-retention` - Retention period for local Papertrail log data. Default value is "4h".
 `--pt-worker-count` - Papertrail log shipper worker count per CPU. Default value is 10. If there are 4 CPUs, the total will be 40.
 `--pt-max-disk-usage` - Papertrail log shipper max disk usage in percent. Default value is 50.
 
 If you want to override the defaults for any of the above flags, they will have to be passed in as arguments to main process.
 
 ### Loggly
-In order to ship logs to papertrail, you will need a loggly account. If you don't have one already you can sign up for one [here](https://www.loggly.com/). After you are logged in, you will need to create a `Customer Token` from under the `Source Setup` menu item.
+In order to ship logs to Loggly, you will need a Loggly account. If you don't have one already you can sign up for one [here](https://www.loggly.com/). After you are logged in, you will need to create a `Customer Token` from under the `Source Setup` menu item.
 
 **Environment variable**
-- `LOGGLY_TOKEN` - customer token from loggly (__not__ API token)
+- `LOGGLY_TOKEN` - customer token from Loggly (__not__ API token)
 
-For any help with loggly, please checkout their help page [here](https://www.loggly.com/docs-index/).
+For any help with Loggly, please checkout their help page [here](https://www.loggly.com/docs-index/).
 
 You can update the `logging-secrets.yaml` and `logging-config-patch.yaml` files accordingly with these values, remove the unused ones and use `kubectl apply...` as described above.
 
 ## Development
 
-You will need Go (1.11+) installed on your machine. Then, clone this repo to a suitable folder location on your machine and `cd` into it. For quick command access the project includes a Makefile.
+You will need Go (1.11+) installed on your machine. Then, clone this repo to a suitable location on your machine and `cd` into it. For quick command access the project includes a Makefile.
 
 To build run:
 ```
@@ -73,7 +73,7 @@ To run tests:
 make tests
 ```
 
-To create a docker image:
+To create a Docker image:
 ```
 make docker
 ```


### PR DESCRIPTION
When I was setting this up, I was slightly confused by the wording for the `PAPERTRAIL_PROTOCOL` env variable saying TLS and UDP are the default choices. I wasn't sure if that meant it would set a default for me, and after seeing it didn't, I thought a small change of words could eliminate any potential confusion in the future.

Also capitalized a few references to Papertrail.