### PR TITLE
Remove chmod 777

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ FROM alpine
 COPY --from=main /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=main /etc/ssl/certs/papertrail-bundle.pem /etc/ssl/certs/
 COPY --from=main /rkubelog /app/rkubelog
-RUN chmod -R 777 /app
 USER 1001
 WORKDIR /app
 ENTRYPOINT ./rkubelog


### PR DESCRIPTION
* `/app/rkubelog` already has execute bit set after go build
* `RUN` step makes `/app/rkubelog` world writable

After building image on Linux with this commit applied - `make docker`:

```
total 26388
-rwxr-xr-x    1 root     root      27021312 Nov 16 01:23 rkubelog
```

vs v17 image:

```shell
total 26392
-rwxrwxrwx    1 root     root      27021312 Oct  1 18:07 rkubelog
```