### PR TITLE
Adds check to automatically restart rkubelog every 24 hours

### DIFF
--- a/rkubelog/deployment.yaml
+++ b/rkubelog/deployment.yaml
@@ -26,3 +26,9 @@ spec:
         name: "rkubelog"
         command:
         - /app/rkubelog
+        livenessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - "end=$(date -u +%s); start=$(stat -c %Z /proc/1 | awk '{print int($1)}'); test $(($end-$start)) -lt 86400"


### PR DESCRIPTION
Since using rkubelog, we've experienced quite often that all or even worse, just some log sources are no longer sent to papertrail.

The only way we've found to work around the problem is to restart the rkubelog pod. This is also the advice given in the readme.

To avoid having to restart the logging solution all the time and to give peace of mind that we're actually receiving all our logs - not just some of them, we've implemented an automatic restart of rkubelog every 24 hours.

Here's our code if it could be useful for the project until the underlying issue is fixed. (FYI: I closed the prior PR due to a mistake in the code and not wanting it to be merged by accident)