### PR TITLE
SP-4908_use_GitHub_docker_repo

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,7 +8,7 @@ on:
     types: [published]
 
 env:
-  IMAGE_NAME: "quay.io/solarwinds/rkubelog"
+  IMAGE_NAME: "ghcr.io/solarwinds/rkubelog"
 
 jobs:
   build:
@@ -23,9 +23,9 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v1
         with:
-          registry: quay.io
-          username: turbo
-          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker build & push
         run: |
           DOCKER_BUILDKIT=1 docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 --no-cache --push -t ${{ env.IMAGE_NAME }}:${GITHUB_REF:10} -t ${{ env.IMAGE_NAME }}:latest .


### PR DESCRIPTION
The rKubelog container is currently pushed to quay.io repository. This repository is now owned by N-able so the images were moved to https://github.com/orgs/solarwinds/packages/container/package/rkubelog.
Documentation task: https://swicloud.atlassian.net/browse/SP-4956