### PR TITLE
use new GitHub image repository

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ on:
       - 'rkubelog/**'
 
 env:
-  IMAGE_NAME: "quay.io/solarwinds/rkubelog"
+  IMAGE_NAME: "ghcr.io/solarwinds/rkubelog"
 
 jobs:
   checks:

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ build:
 	go build -mod vendor -o bin/rkubelog
 
 docker:
-	DOCKER_BUILDKIT=1 docker build -t quay.io/solarwinds/rkubelog .
+	DOCKER_BUILDKIT=1 docker build -t ghcr.io/solarwinds/rkubelog .

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ rkubelog is the easiest way to get logs out of your k8s cluster and into [Papert
 
 ## Usage
 
-> __Info:__ Make sure to always reference rkubelog versions explicitly in the image. Do not use `latest` tags. The current version is `quay.io/solarwinds/rkubelog:<github_version>`, where `github_version` is the latest revision listed in [Releases](https://github.com/solarwinds/rkubelog/releases), for example `r17`.
+> __Info:__ Make sure to always reference rkubelog versions explicitly in the image. Do not use `latest` tags. The current version is `ghcr.io/solarwinds/rkubelog:<github_version>`, where `github_version` is the latest revision listed in [Releases](https://github.com/solarwinds/rkubelog/releases), for example `r17`.
 
 By default, rkubelog runs in the `kube-system` namespace and will observe all logs from all pods in all namespaces except from itself or any other service in `kube-system`.
 

--- a/rkubelog/deployment.yaml
+++ b/rkubelog/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: rkubelog-sa
       containers:
-      - image: quay.io/solarwinds/rkubelog:r18
+      - image: ghcr.io/solarwinds/rkubelog:r18
         imagePullPolicy: Always
         name: "rkubelog"
         command:


### PR DESCRIPTION
Image repository changed from quay.io/solarwinds/rkubelog to ghcr.io/solarwinds/rkubelog
The old repository is not owned by Solarwinds company anymore.